### PR TITLE
update exception flag for missing blob

### DIFF
--- a/datamanagement/remove_deleted.py
+++ b/datamanagement/remove_deleted.py
@@ -90,7 +90,7 @@ def main(
         if not dry_run:
             try:
                 storage_client.delete(file_resource['filename'])
-            except FileNotFoundError:
+            except:
                 logging.exception('file already deleted')
 
         # Delete the instance model from tantalus


### PR DESCRIPTION
remove_deleted.py is throwing an error when a blob doesn't exist. It looks like the error type has changed and is not being caught by the current exception. Generalized the exception. 